### PR TITLE
[bugfix]: clean OCI leftovers before the wasp-agent pod is removed

### DIFF
--- a/manifests/openshift/ds.yaml
+++ b/manifests/openshift/ds.yaml
@@ -30,6 +30,14 @@ spec:
             quay.io/openshift-virtualization/wasp-agent:v4.17
           imagePullPolicy: Always
           name: wasp-agent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - rm
+                  - -f
+                  - /host/opt/oci-hook-swap.sh
+                  - /host/run/containers/oci/hooks.d/swap-for-burstable.json
           resources:
             requests:
               cpu: 100m

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,0 +1,10 @@
+package consts
+
+const (
+	HookTemplateFile     = "/app/OCI-hook/hookscript.template"
+	HookScriptPath       = "/host/opt/oci-hook-swap.sh"
+	HookConfigSource     = "/app/OCI-hook/swap-for-burstable.json"
+	HookConfigPath       = "/host/run/containers/oci/hooks.d/swap-for-burstable.json"
+	CrioConfigPath       = "/host/etc/crio/crio.conf"
+	CrioConfigDropInPath = "/host/etc/crio/crio.conf.d"
+)

--- a/pkg/wasp/application.go
+++ b/pkg/wasp/application.go
@@ -22,14 +22,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
+	"os"
 	"github.com/openshift-virtualization/wasp-agent/pkg/client"
 	"github.com/openshift-virtualization/wasp-agent/pkg/informers"
 	"github.com/openshift-virtualization/wasp-agent/pkg/log"
 	limited_swap_manager "github.com/openshift-virtualization/wasp-agent/pkg/wasp/limited-swap-manager"
-	"io"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	"os"
 )
 
 type WaspApp struct {

--- a/pkg/wasp/oci.go
+++ b/pkg/wasp/oci.go
@@ -9,8 +9,10 @@ import (
 )
 
 const (
-	hookTemplateFile = "/app/OCI-hook/hookscript.template"
-	hookScriptPath   = "/host/opt/oci-hook-swap.sh"
+	hookTemplateFile  = "/app/OCI-hook/hookscript.template"
+	hookScriptPath    = "/host/opt/oci-hook-swap.sh"
+	hookConfigSource  = "/app/OCI-hook/swap-for-burstable.json"
+	hookConfigPath    = "/host/run/containers/oci/hooks.d/swap-for-burstable.json"
 	// CrioConfigPath is the default location for the conf file.
 	CrioConfigPath = "/host/etc/crio/crio.conf"
 	// CrioConfigDropInPath is the default location for the drop-in config files.
@@ -31,13 +33,14 @@ func setOCIHook() error {
 		return err
 	}
 
-	err = moveFile("/app/OCI-hook/swap-for-burstable.json", "/host/run/containers/oci/hooks.d/swap-for-burstable.json")
+	err = moveFile(hookConfigSource, hookConfigPath)
 	if err != nil {
 		return err
 	}
 
 	return nil
 }
+
 
 func setupHookScript() error {
 	crioConfig := crioConfiguration(config.New(CrioConfigPath, CrioConfigDropInPath))

--- a/pkg/wasp/oci.go
+++ b/pkg/wasp/oci.go
@@ -2,21 +2,12 @@ package wasp
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/openshift-virtualization/wasp-agent/pkg/consts"
 	"github.com/openshift-virtualization/wasp-agent/pkg/wasp/config"
 	oci_hook_render "github.com/openshift-virtualization/wasp-agent/pkg/wasp/oci-hook-render"
 	"k8s.io/klog/v2"
-	"os"
-)
-
-const (
-	hookTemplateFile  = "/app/OCI-hook/hookscript.template"
-	hookScriptPath    = "/host/opt/oci-hook-swap.sh"
-	hookConfigSource  = "/app/OCI-hook/swap-for-burstable.json"
-	hookConfigPath    = "/host/run/containers/oci/hooks.d/swap-for-burstable.json"
-	// CrioConfigPath is the default location for the conf file.
-	CrioConfigPath = "/host/etc/crio/crio.conf"
-	// CrioConfigDropInPath is the default location for the drop-in config files.
-	CrioConfigDropInPath = "/host/etc/crio/crio.conf.d"
 )
 
 type crioConfiguration interface {
@@ -33,7 +24,7 @@ func setOCIHook() error {
 		return err
 	}
 
-	err = moveFile(hookConfigSource, hookConfigPath)
+	err = moveFile(consts.HookConfigSource, consts.HookConfigPath)
 	if err != nil {
 		return err
 	}
@@ -43,19 +34,19 @@ func setOCIHook() error {
 
 
 func setupHookScript() error {
-	crioConfig := crioConfiguration(config.New(CrioConfigPath, CrioConfigDropInPath))
+	crioConfig := crioConfiguration(config.New(consts.CrioConfigPath, consts.CrioConfigDropInPath))
 	runtime, err := crioConfig.GetRuntime()
 	if err != nil {
 		return err
 	}
 	klog.Infof("detected runtime " + runtime)
 
-	renderer := hookRenderer(oci_hook_render.New(hookTemplateFile, hookScriptPath, runtime))
+	renderer := hookRenderer(oci_hook_render.New(consts.HookTemplateFile, consts.HookScriptPath, runtime))
 	if err := renderer.Render(); err != nil {
 		return err
 	}
 
-	err = os.Chmod(hookScriptPath, 0755)
+	err = os.Chmod(consts.HookScriptPath, 0755)
 	if err != nil {
 		return fmt.Errorf("Couldn't set file permissions: %v", err)
 	}

--- a/pkg/wasp/resources/operator/operator.go
+++ b/pkg/wasp/resources/operator/operator.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"fmt"
+
+	"github.com/openshift-virtualization/wasp-agent/pkg/consts"
 	"github.com/openshift-virtualization/wasp-agent/pkg/monitoring/rules"
 	utils2 "github.com/openshift-virtualization/wasp-agent/pkg/util"
 
@@ -122,8 +124,8 @@ func createWaspDaemonSet(namespace, verbosity, waspImage, pullPolicy string) *ap
 				Exec: &corev1.ExecAction{
 					Command: []string{
 						"rm", "-f",
-						"/host/opt/oci-hook-swap.sh",
-						"/host/run/containers/oci/hooks.d/swap-for-burstable.json",
+						consts.HookScriptPath,
+						consts.HookConfigPath,
 					},
 				},
 			},

--- a/pkg/wasp/resources/operator/operator.go
+++ b/pkg/wasp/resources/operator/operator.go
@@ -117,6 +117,17 @@ func createWaspDaemonSet(namespace, verbosity, waspImage, pullPolicy string) *ap
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: boolPtr(true),
 		},
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"rm", "-f",
+						"/host/opt/oci-hook-swap.sh",
+						"/host/run/containers/oci/hooks.d/swap-for-burstable.json",
+					},
+				},
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "host",


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

two OCI files are being copied by wasp-agent into the host:
hook configuration and hook script. These files remain on the
filesystem even after wasp-agent is being removed from the node.
This causes redundant execution of the OCI hook.
    
these changes suggest removing the files before the pod terminates.
The preStop hook is being called before SIGTERM is being sent to the pod.
    
In case of forcefull deletion the hook will be skipped